### PR TITLE
fix bug on str to int on -k is float

### DIFF
--- a/src/Monopogen.py
+++ b/src/Monopogen.py
@@ -179,7 +179,7 @@ def somatic(args):
 			cell_clst = pd.read_csv(args.barcode)   
 			df = pd.DataFrame(cell_clst, columns= ['cell','id'])
 			df = df.sort_values(by=['id'])
-			args.keep = int(args.keep)
+			args.keep = float(args.keep)
 			if args.keep < 1:
 				dis = np.cumsum(df['id'])/np.sum(df['id'])
 				N = sum(dis>(1-args.keep))


### PR DESCRIPTION
Need to change `int` to `float` function. Because when k=0.6 is passed in, you will get this error: `ValueError: invalid literal for int() with base 10: '0.6'`